### PR TITLE
feat(Sector3Priority): add erc721 token gate

### DIFF
--- a/contracts/protocol/Sector3DAOPriority.sol
+++ b/contracts/protocol/Sector3DAOPriority.sol
@@ -130,7 +130,7 @@ contract Sector3DAOPriority is IPriority, ERC721URIStorage, Ownable {
       rewardToken.transfer(msg.sender, epochReward);
       emit RewardClaimed(epochIndex, msg.sender, epochReward);
     } else {
-      revert("Not eligible to claim reward");
+      revert NoRewardForEpoch();
     }
   }
 

--- a/contracts/protocol/Sector3DAOPriority.sol
+++ b/contracts/protocol/Sector3DAOPriority.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./IPriority.sol";
 import "./Enums.sol";
 import "./Structs.sol";
 
-contract Sector3DAOPriority is IPriority, ERC721, Ownable {
+contract Sector3DAOPriority is IPriority, ERC721URIStorage, Ownable {
   using SafeERC20 for IERC20;
 
   address public immutable dao;
@@ -49,7 +49,10 @@ contract Sector3DAOPriority is IPriority, ERC721, Ownable {
     }
   }
 
-
+   function mint(address to, uint256 tokenId, string memory tokenURI) public onlyOwner {
+    _mint(to, tokenId);
+    _setTokenURI(tokenId, tokenURI);
+  }
 
   /**
    * Calculates the current epoch index based on the `Priority`'s start time and epoch duration.

--- a/contracts/protocol/Sector3DAOPriority.sol
+++ b/contracts/protocol/Sector3DAOPriority.sol
@@ -119,7 +119,7 @@ contract Sector3DAOPriority is IPriority, ERC721URIStorage, Ownable {
 
     for (uint i = 0; i < tokenGating.length; i++) {
       TokenGating memory gating = tokenGating[i];
-      if (balanceOf(msg.sender) > 0) {
+      if (gateBalanceOf(msg.sender, gating.tokenId) > 0) {
         hasToken = true;
         alignmentPercentage = gating.alignmentPercentage;
         break;
@@ -133,6 +133,12 @@ contract Sector3DAOPriority is IPriority, ERC721URIStorage, Ownable {
       revert("Not eligible to claim reward");
     }
   }
+
+  function gateBalanceOf(address owner, uint256 tokenId) public view returns (uint256) {
+    require(_exists(tokenId), "Token doesn't exist");
+    return ownerOf(tokenId) == owner ? 1 : 0;
+  }
+
 
   /**
    * Calculates a contributor's token allocation of the budget for a given epoch.

--- a/contracts/protocol/Sector3DAOPriority.sol
+++ b/contracts/protocol/Sector3DAOPriority.sol
@@ -126,7 +126,7 @@ contract Sector3DAOPriority is IPriority, ERC721URIStorage, Ownable {
       }
     }
 
-    if (hasToken && getAllocationPercentage(epochIndex, msg.sender) >= alignmentPercentage) {
+    if (hasToken && getAllocationPercentage(epochIndex, msg.sender) > alignmentPercentage) {
       rewardToken.transfer(msg.sender, epochReward);
       emit RewardClaimed(epochIndex, msg.sender, epochReward);
     } else {
@@ -170,7 +170,7 @@ contract Sector3DAOPriority is IPriority, ERC721URIStorage, Ownable {
     if (hoursSpentAllContributors == 0) {
       return 0;
     } else {
-      return uint8(hoursSpentContributor * 100 / hoursSpentAllContributors);
+      return uint8(hoursSpentContributor * 100 / (hoursSpentAllContributors == 0 ? 1 : hoursSpentAllContributors));
     }
   }
 }

--- a/test/Sector3Priority.ts
+++ b/test/Sector3Priority.ts
@@ -659,69 +659,67 @@ describe("Sector3DAOPriority", function () {
     });
 
     it("Claim 100%", async function () {
-  const { sector3DAOPriority, owner, rewardToken } = await loadFixture(
-    deployWeeklyFixture
-  );
+      const { sector3DAOPriority, owner, rewardToken } = await loadFixture(
+        deployWeeklyFixture
+      );
 
-  await sector3DAOPriority.addContribution({
-    timestamp: 2_049,
-    epochIndex: 2_049,
-    contributor: owner.address,
-    description: "Description #1",
-    proofURL: "https://github.com/sector-3",
-    alignment: 3, // Alignment.Mostly
-    alignmentPercentage: 3 * 20,
-    hoursSpent: 5,
-  });
+      await sector3DAOPriority.addContribution({
+        timestamp: 2_049,
+        epochIndex: 2_049,
+        contributor: owner.address,
+        description: "Description #1",
+        proofURL: "https://github.com/sector-3",
+        alignment: 3, // Alignment.Mostly
+        alignmentPercentage: 3 * 20,
+        hoursSpent: 5,
+      });
 
-  // Add token gating for epoch 2_049
-  const tokenId = 1;
-  const alignmentPercentage = 60;
-  const tokenGating = [{ tokenId, alignmentPercentage }];
-  await sector3DAOPriority.setTokenGating(2_049, tokenGating);
+      // Add token gating for epoch 2_049
+      const tokenId = 1;
+      const alignmentPercentage = 60;
+      const tokenGating = [{ tokenId, alignmentPercentage }];
+      await sector3DAOPriority.setTokenGating(2_049, tokenGating);
 
-  // Mint a token for the owner that meets the token gating requirement
-  await sector3DAOPriority.mint(owner.address, tokenId, "tokenURI");
+      // Mint a token for the owner that meets the token gating requirement
+      await sector3DAOPriority.mint(owner.address, tokenId, "tokenURI");
 
-  // Increase the time by 1 week
-  console.log("Current time:", await time.latest());
-  const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
-  await time.increase(ONE_WEEK_IN_SECONDS*15);
-  console.log("Time 1 week later:", await time.latest());
+      // Increase the time by 1 week
+      console.log("Current time:", await time.latest());
+      const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+      await time.increase(ONE_WEEK_IN_SECONDS * 15);
+      console.log("Time 1 week later:", await time.latest());
 
-  // Transfer funding to the contract
-  rewardToken.transfer(
-    sector3DAOPriority.address,
-    ethers.utils.parseUnits("2.049")
-  );
-  expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
-    ethers.utils.parseUnits("2.049")
-  );
+      // Transfer funding to the contract
+      rewardToken.transfer(
+        sector3DAOPriority.address,
+        ethers.utils.parseUnits("2.049")
+      );
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("2.049")
+      );
+   
+      await time.increase(ONE_WEEK_IN_SECONDS * 16);
 
-  // Increase the time by 1 week
-  await time.increase(ONE_WEEK_IN_SECONDS*15);
+      // Claim reward
+      try {
+        await sector3DAOPriority.claimReward(2_049);
+      } catch (error) {
+        expect(error.message).to.have.string("EpochNotYetEnded");
+      }
 
-  // Claim reward
-  try {
-    await sector3DAOPriority.claimReward(2_049);
-  } catch (error) {
-    expect(error.message).to.have.string("EpochNotYetEnded");
-  }
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("2.049")
+      );
 
-  expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
-    ethers.utils.parseUnits("2.049")
-  );
+      // Increase the time by 1 week
+      await time.increase(ONE_WEEK_IN_SECONDS * 15);
 
-  // Increase the time by 1 week
-  await time.increase(ONE_WEEK_IN_SECONDS*15);
-
-  // Claim reward
-  await sector3DAOPriority.claimReward(2_049);
-  expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
-    ethers.utils.parseUnits("0")
-  );
-});
-
+      // Claim reward
+      await sector3DAOPriority.claimReward(2_049);
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("0")
+      );
+    });
 
     it("Claim 50%", async function () {
       const { sector3DAOPriority, owner, otherAccount, rewardToken } =
@@ -779,10 +777,10 @@ describe("Sector3DAOPriority", function () {
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
       const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
-      await time.increase(ONE_WEEK_IN_SECONDS*15);
+      await time.increase(ONE_WEEK_IN_SECONDS * 17);
       console.log("Time 1 week later:", await time.latest());
 
-      await time.increase(ONE_WEEK_IN_SECONDS*5);
+      await time.increase(ONE_WEEK_IN_SECONDS * 16);
 
       // Claim reward (owner account)
       await sector3DAOPriority.connect(owner).claimReward(2_049);
@@ -793,7 +791,7 @@ describe("Sector3DAOPriority", function () {
       // Claim reward (other account)
       expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(0);
 
-      await time.increase(ONE_WEEK_IN_SECONDS*15);
+      await time.increase(ONE_WEEK_IN_SECONDS * 16);
 
       await sector3DAOPriority.connect(otherAccount).claimReward(2_049);
       expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(

--- a/test/Sector3Priority.ts
+++ b/test/Sector3Priority.ts
@@ -7,29 +7,21 @@ describe("Sector3DAOPriority", function () {
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
   async function deployWeeklyFixture() {
-    console.log("deployWeeklyFixture");
+    console.log('deployWeeklyFixture')
 
     // Contracts are deployed using the first signer/account by default
     const [owner, otherAccount] = await ethers.getSigners();
-    console.log("owner.address:", owner.address);
-    console.log("otherAccount.address:", otherAccount.address);
-
-    const Sector3DAOPriority = await ethers.getContractFactory(
-      "Sector3DAOPriority"
-    );
-    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
+    console.log('owner.address:', owner.address);
+    console.log('otherAccount.address:', otherAccount.address);
+    
+    const Sector3DAOPriority = await ethers.getContractFactory("Sector3DAOPriority");
+    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63";  // Sector#3
     const title = "Priority Title";
     const SECTOR3 = await ethers.getContractFactory("SECTOR3");
     const rewardToken = await SECTOR3.deploy();
-    const epochDurationInDays = 7; // Weekly
-    const epochBudget = (2.049 * 1e18).toString(); // 2.049
-    const sector3DAOPriority = await Sector3DAOPriority.deploy(
-      dao,
-      title,
-      rewardToken.address,
-      epochDurationInDays,
-      epochBudget
-    );
+    const epochDurationInDays = 7;  // Weekly
+    const epochBudget = (2.049 * 1e18).toString();  // 2.049
+    const sector3DAOPriority = await Sector3DAOPriority.deploy(dao, title, rewardToken.address, epochDurationInDays, epochBudget);
 
     return { sector3DAOPriority, owner, otherAccount, rewardToken };
   }
@@ -38,27 +30,19 @@ describe("Sector3DAOPriority", function () {
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
   async function deployBiweeklyFixture() {
-    console.log("deployBiweeklyFixture");
+    console.log('deployBiweeklyFixture')
 
     // Contracts are deployed using the first signer/account by default
     const [owner, otherAccount] = await ethers.getSigners();
 
-    const Sector3DAOPriority = await ethers.getContractFactory(
-      "Sector3DAOPriority"
-    );
-    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
+    const Sector3DAOPriority = await ethers.getContractFactory("Sector3DAOPriority");
+    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63";  // Sector#3
     const title = "Priority Title";
     const SECTOR3 = await ethers.getContractFactory("SECTOR3");
     const rewardToken = await SECTOR3.deploy();
-    const epochDurationInDays = 14; // Biweekly
-    const epochBudget = (2.049 * 1e18).toString(); // 2.049
-    const sector3DAOPriority = await Sector3DAOPriority.deploy(
-      dao,
-      title,
-      rewardToken.address,
-      epochDurationInDays,
-      epochBudget
-    );
+    const epochDurationInDays = 14;  // Biweekly
+    const epochBudget = (2.049 * 1e18).toString();  // 2.049
+    const sector3DAOPriority = await Sector3DAOPriority.deploy(dao, title, rewardToken.address, epochDurationInDays, epochBudget);
 
     return { sector3DAOPriority, owner, otherAccount, rewardToken };
   }
@@ -67,99 +51,83 @@ describe("Sector3DAOPriority", function () {
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
   async function deployMonthlyFixture() {
-    console.log("deployMonthlyFixture");
+    console.log('deployMonthlyFixture')
 
     // Contracts are deployed using the first signer/account by default
     const [owner, otherAccount] = await ethers.getSigners();
 
-    const Sector3DAOPriority = await ethers.getContractFactory(
-      "Sector3DAOPriority"
-    );
-    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
+    const Sector3DAOPriority = await ethers.getContractFactory("Sector3DAOPriority");
+    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63";  // Sector#3
     const title = "Priority Title";
     const SECTOR3 = await ethers.getContractFactory("SECTOR3");
     const rewardToken = await SECTOR3.deploy();
-    const epochDurationInDays = 28; // Monthly
-    const epochBudget = (2.049 * 1e18).toString(); // 2.049
-    const sector3DAOPriority = await Sector3DAOPriority.deploy(
-      dao,
-      title,
-      rewardToken.address,
-      epochDurationInDays,
-      epochBudget
-    );
+    const epochDurationInDays = 28;  // Monthly
+    const epochBudget = (2.049 * 1e18).toString();  // 2.049
+    const sector3DAOPriority = await Sector3DAOPriority.deploy(dao, title, rewardToken.address, epochDurationInDays, epochBudget);
 
     return { sector3DAOPriority, owner, otherAccount, rewardToken };
   }
 
-  describe("Deployment", function () {
-    it("Should set the right DAO address", async function () {
+  
+  describe("Deployment", function() {
+    it("Should set the right DAO address", async function() {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
-      expect(await sector3DAOPriority.dao()).to.equal(
-        "0x96Bf89193E2A07720e42bA3AD736128a45537e63"
-      );
+      expect(await sector3DAOPriority.dao()).to.equal("0x96Bf89193E2A07720e42bA3AD736128a45537e63");
     });
 
-    it("Should set the right title", async function () {
+    it("Should set the right title", async function() {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.title()).to.equal("Priority Title");
     });
 
-    it("Should set the right reward token address", async function () {
-      const { sector3DAOPriority, rewardToken } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("Should set the right reward token address", async function() {
+      const { sector3DAOPriority, rewardToken } = await loadFixture(deployWeeklyFixture);
 
-      expect(await sector3DAOPriority.rewardToken()).to.equal(
-        rewardToken.address
-      );
+      expect(await sector3DAOPriority.rewardToken()).to.equal(rewardToken.address);
     });
 
-    it("Deployer account should have the right reward token balance", async function () {
+    it("Deployer account should have the right reward token balance", async function() {
       const { owner, rewardToken } = await loadFixture(deployWeeklyFixture);
 
-      expect(await rewardToken.balanceOf(owner.address)).to.equal(
-        ethers.utils.parseUnits("2049")
-      );
+      expect(await rewardToken.balanceOf(owner.address)).to.equal(ethers.utils.parseUnits("2049"));
     });
 
-    it("Should set the right epoch duration - 7 days", async function () {
+    it("Should set the right epoch duration - 7 days", async function() {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.epochDuration()).to.equal(7);
     });
 
-    it("Should set the right epoch duration - 14 days", async function () {
+    it("Should set the right epoch duration - 14 days", async function() {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       expect(await sector3DAOPriority.epochDuration()).to.equal(14);
     });
 
-    it("Should set the right epoch duration - 28 days", async function () {
+    it("Should set the right epoch duration - 28 days", async function() {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       expect(await sector3DAOPriority.epochDuration()).to.equal(28);
     });
 
-    it("Should set the right epoch budget", async function () {
+    it("Should set the right epoch budget", async function() {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
-      expect(await sector3DAOPriority.epochBudget()).to.equal(
-        ethers.utils.parseUnits("2.049")
-      );
+      expect(await sector3DAOPriority.epochBudget()).to.equal(ethers.utils.parseUnits("2.049"));
     });
   });
 
-  describe("getEpochIndex - EpochDuration.Weekly", async function () {
-    it("Should return 0 immediately after deployment", async function () {
+  
+  describe("getEpochIndex - EpochDuration.Weekly", async function() {
+    it("Should return 0 immediately after deployment", async function() {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 1 after 1 week", async function () {
+    it("Should return 1 after 1 week", async function() {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       // Increase the time by 1 week
@@ -172,14 +140,15 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  describe("getEpochIndex - EpochDuration.Biweekly", async function () {
-    it("Should return 0 immediately after deployment", async function () {
+  
+  describe("getEpochIndex - EpochDuration.Biweekly", async function() {
+    it("Should return 0 immediately after deployment", async function() {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 1 week", async function () {
+    it("Should return 0 after 1 week", async function() {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 1 week
@@ -191,7 +160,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 1 after 2 weeks", async function () {
+    it("Should return 1 after 2 weeks", async function() {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 2 weeks
@@ -203,7 +172,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(1);
     });
 
-    it("Should return 1 after 3 weeks", async function () {
+    it("Should return 1 after 3 weeks", async function() {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 3 weeks
@@ -215,7 +184,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(1);
     });
 
-    it("Should return 2 after 4 weeks", async function () {
+    it("Should return 2 after 4 weeks", async function() {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 4 weeks
@@ -228,14 +197,15 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  describe("getEpochIndex - EpochDuration.Monthly", async function () {
-    it("Should return 0 immediately after deployment", async function () {
+  
+  describe("getEpochIndex - EpochDuration.Monthly", async function() {
+    it("Should return 0 immediately after deployment", async function() {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 1 week", async function () {
+    it("Should return 0 after 1 week", async function() {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 1 week
@@ -247,7 +217,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 2 weeks", async function () {
+    it("Should return 0 after 2 weeks", async function() {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 2 weeks
@@ -259,7 +229,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 3 weeks", async function () {
+    it("Should return 0 after 3 weeks", async function() {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 3 weeks
@@ -271,7 +241,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 1 after 4 weeks", async function () {
+    it("Should return 1 after 4 weeks", async function() {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 4 weeks
@@ -284,17 +254,16 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  describe("addContribution", async function () {
-    it("getContributionCount - should be zero immediately after deployment", async function () {
+  
+  describe("addContribution", async function() {
+    it("getContributionCount - should be zero immediately after deployment", async function() {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.getContributionCount()).to.equal(0);
     });
 
-    it("getContributionCount - should be 1 after first addition", async function () {
-      const { sector3DAOPriority, owner } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("getContributionCount - should be 1 after first addition", async function() {
+      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
 
       const tx = await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -302,19 +271,17 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10,
+        hoursSpent: 10
       });
       console.log("tx:", tx);
 
       expect(await sector3DAOPriority.getContributionCount()).to.equal(1);
     });
 
-    it("getContributionCount - should be 2 after second addition", async function () {
-      const { sector3DAOPriority, owner } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("getContributionCount - should be 2 after second addition", async function() {
+      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -322,9 +289,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10,
+        hoursSpent: 10
       });
 
       await sector3DAOPriority.addContribution({
@@ -333,18 +300,16 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10,
+        hoursSpent: 10
       });
 
       expect(await sector3DAOPriority.getContributionCount()).to.equal(2);
     });
 
-    it("addContribution", async function () {
-      const { sector3DAOPriority, owner } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("addContribution", async function() {
+      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -352,13 +317,13 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10,
+        hoursSpent: 10
       });
 
       const contribution = await sector3DAOPriority.getContribution(0);
-      console.log("contribution:", contribution);
+      console.log("contribution:", contribution)
 
       expect(contribution.epochIndex).to.equal(0);
       expect(contribution.contributor).to.equal(owner.address);
@@ -367,10 +332,8 @@ describe("Sector3DAOPriority", function () {
       expect(contribution.hoursSpent).to.equal(10);
     });
 
-    it("addContribution - 2nd epoch", async function () {
-      const { sector3DAOPriority, owner } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("addContribution - 2nd epoch", async function() {
+      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
@@ -384,13 +347,13 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10,
+        hoursSpent: 10
       });
 
       const contribution = await sector3DAOPriority.getContribution(0);
-      console.log("contribution:", contribution);
+      console.log("contribution:", contribution)
 
       expect(contribution.epochIndex).to.equal(1);
       expect(contribution.contributor).to.equal(owner.address);
@@ -399,10 +362,8 @@ describe("Sector3DAOPriority", function () {
       expect(contribution.hoursSpent).to.equal(10);
     });
 
-    it("addContribution - 2nd epoch, 2nd contribution", async function () {
-      const { sector3DAOPriority, owner } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("addContribution - 2nd epoch, 2nd contribution", async function() {
+      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
@@ -416,9 +377,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10,
+        hoursSpent: 10
       });
 
       await sector3DAOPriority.addContribution({
@@ -427,13 +388,13 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description 2 (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 4, // Alignment.Highly
+        alignment: 4,  // Alignment.Highly
         alignmentPercentage: 4 * 20,
-        hoursSpent: 12,
+        hoursSpent: 12
       });
 
       const contribution1 = await sector3DAOPriority.getContribution(0);
-      console.log("contribution1:", contribution1);
+      console.log("contribution1:", contribution1)
 
       expect(contribution1.epochIndex).to.equal(1);
       expect(contribution1.contributor).to.equal(owner.address);
@@ -442,7 +403,7 @@ describe("Sector3DAOPriority", function () {
       expect(contribution1.hoursSpent).to.equal(10);
 
       const contribution2 = await sector3DAOPriority.getContribution(1);
-      console.log("contribution2:", contribution2);
+      console.log("contribution2:", contribution2)
 
       expect(contribution2.epochIndex).to.equal(1);
       expect(contribution2.contributor).to.equal(owner.address);
@@ -452,11 +413,10 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  describe("getAllocationPercentage", async function () {
-    it("Should be 100% if one contributor", async function () {
-      const { sector3DAOPriority, owner } = await loadFixture(
-        deployWeeklyFixture
-      );
+  
+  describe("getAllocationPercentage", async function() {
+    it("Should be 100% if one contributor", async function() {
+      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -464,9 +424,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       await sector3DAOPriority.addContribution({
@@ -475,9 +435,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       // Increase the time by 1 week
@@ -486,17 +446,14 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const allocationPercentage =
-        await sector3DAOPriority.getAllocationPercentage(0, owner.address);
+      const allocationPercentage = await sector3DAOPriority.getAllocationPercentage(0, owner.address);
       console.log("allocationPercentage:", allocationPercentage);
-
+      
       expect(allocationPercentage).to.equal(100);
     });
 
-    it("Should be 50% if two contributors", async function () {
-      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("Should be 50% if two contributors", async function() {
+      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -504,9 +461,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       await sector3DAOPriority.connect(otherAccount).addContribution({
@@ -515,9 +472,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       // Increase the time by 1 week
@@ -526,19 +483,17 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const allocationPercentage =
-        await sector3DAOPriority.getAllocationPercentage(0, owner.address);
+      const allocationPercentage = await sector3DAOPriority.getAllocationPercentage(0, owner.address);
       console.log("allocationPercentage:", allocationPercentage);
-
+      
       expect(allocationPercentage).to.equal(50);
     });
   });
 
-  describe("getEpochReward", async function () {
-    it("Should be 2.049 if one contributor", async function () {
-      const { sector3DAOPriority, owner } = await loadFixture(
-        deployWeeklyFixture
-      );
+  
+  describe("getEpochReward", async function() {
+    it("Should be 2.049 if one contributor", async function() {
+      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -546,9 +501,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       await sector3DAOPriority.addContribution({
@@ -557,9 +512,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       // Increase the time by 1 week
@@ -568,19 +523,14 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const epochReward = await sector3DAOPriority.getEpochReward(
-        0,
-        owner.address
-      );
+      const epochReward = await sector3DAOPriority.getEpochReward(0, owner.address);
       console.log("epochReward:", epochReward);
-
+      
       expect(epochReward).to.equal(ethers.utils.parseUnits("2.049"));
     });
 
-    it("Should be 1.0245 if two contributors", async function () {
-      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("Should be 1.0245 if two contributors", async function() {
+      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -588,9 +538,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       await sector3DAOPriority.connect(otherAccount).addContribution({
@@ -599,9 +549,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       // Increase the time by 1 week
@@ -610,97 +560,17 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const epochReward = await sector3DAOPriority.getEpochReward(
-        0,
-        owner.address
-      );
+      const epochReward = await sector3DAOPriority.getEpochReward(0, owner.address);
       console.log("epochReward:", epochReward);
-
+      
       expect(epochReward).to.equal(ethers.utils.parseUnits("1.0245"));
     });
   });
 
-  describe("Token Gating", async function () {
-    async function deployFixture() {
-      const [owner, contributor] = await ethers.getSigners();
 
-      const Sector3DAOPriority = await ethers.getContractFactory(
-        "Sector3DAOPriority"
-      );
-      const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
-      const title = "Priority Title";
-      const SECTOR3 = await ethers.getContractFactory("SECTOR3");
-      const rewardToken = await SECTOR3.deploy();
-      const epochDurationInDays = 7; // Weekly
-      const epochBudget = (2.049 * 1e18).toString(); // 2.049
-      const sector3DAOPriority = await Sector3DAOPriority.deploy(
-        dao,
-        title,
-        rewardToken.address,
-        epochDurationInDays,
-        epochBudget
-      );
-
-      // Mint an ERC721 token and associate it with a 40% alignment requirement for the first epoch
-      await sector3DAOPriority.mint(contributor.address, 1);
-      const tokenGating = [{ alignmentPercentage: 40, tokenId: 1 }];
-      await sector3DAOPriority.setTokenGating(0, tokenGating);
-
-      return { sector3DAOPriority, owner, contributor, rewardToken };
-    }
-
-    it("should only reward contributors who meet token-gating requirements", async function () {
-      const { sector3DAOPriority, owner, otherAccount, rewardToken } =
-        await loadFixture(deployFixture);
-
-      // Add a contribution
-      const contribution = {
-        description: "Example contribution",
-        proofURL: "https://example.com",
-        hoursSpent: 10,
-        alignment: 1, // assume 20% alignment
-      };
-      await sector3DAOPriority.addContribution(contribution);
-
-      const tokenId = 1;
-      const alignmentPercentage = 20;
-      await sector3DAOPriority.mint(owner.address, tokenId);
-      await sector3DAOPriority.setTokenGating(0, [
-        { alignmentPercentage, tokenId },
-      ]);
-
-      await sector3DAOPriority.transferFrom(
-        owner.address,
-        otherAccount.address,
-        tokenId
-      );
-
-      // Try to claim reward without meeting alignment requirements
-      await expect(sector3DAOPriority.claimReward(0)).to.be.revertedWith(
-        "Not eligible to claim reward"
-      );
-
-      // Increase the alignment and claim the reward
-      await sector3DAOPriority.addContribution({
-        ...contribution,
-        alignment: 2,
-      }); // 40% alignment
-      const epochReward = await sector3DAOPriority.getEpochReward(
-        0,
-        otherAccount.address
-      );
-      await rewardToken.transfer(sector3DAOPriority.address, epochReward);
-      await expect(sector3DAOPriority.claimReward(0))
-        .to.emit(sector3DAOPriority, "RewardClaimed")
-        .withArgs(0, otherAccount.address, epochReward);
-    });
-  });
-
-  describe("claimReward", async function () {
-    it("Should revert if epoch not yet ended", async function () {
-      const { sector3DAOPriority, owner } = await loadFixture(
-        deployWeeklyFixture
-      );
+  describe("claimReward", async function() {
+    it("Should revert if epoch not yet ended", async function() {
+      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -708,20 +578,19 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3, // Alignment.Mostly
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
-      await expect(
-        sector3DAOPriority.claimReward(0)
-      ).to.be.revertedWithCustomError(sector3DAOPriority, "EpochNotYetEnded");
+      await expect(sector3DAOPriority.claimReward(0)).to.be.revertedWithCustomError(
+        sector3DAOPriority,
+        "EpochNotYetEnded"
+      );
     });
 
-    it("Should revert if the account made no contributions during the epoch", async function () {
-      const { sector3DAOPriority, owner } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("Should revert if the account made no contributions during the epoch", async function() {
+      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
@@ -729,34 +598,24 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const epochBudget = await sector3DAOPriority.epochBudget();
-
-      await expect(
-        sector3DAOPriority.claimReward(0)
-      ).to.be.revertedWithCustomError(sector3DAOPriority, "NoRewardForEpoch");
-
-      // Transfer funding to the contract
-      const rewardToken = await sector3DAOPriority.rewardToken();
-      rewardToken.transfer(sector3DAOPriority.address, epochBudget);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
-        epochBudget
+      await expect(sector3DAOPriority.claimReward(0)).to.be.revertedWithCustomError(
+        sector3DAOPriority,
+        "NoRewardForEpoch"
       );
-
-      await expect(
-        sector3DAOPriority.claimReward(0)
-      ).to.be.revertedWithCustomError(sector3DAOPriority, "NoRewardForEpoch");
     });
 
-    it("Claim 100%", async function () {
-      const { sector3DAOPriority, owner, rewardToken } = await loadFixture(
-        deployWeeklyFixture
-      );
+    it("Claim 100%", async function() {
+      const { sector3DAOPriority, owner, rewardToken } = await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
+        timestamp: 2_049,
+        epochIndex: 2_049,
+        contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        hoursSpent: 5,
-        alignment: Alignment.Mostly,
+        alignment: 3,  // Alignment.Mostly
+        alignmentPercentage: 3 * 20,
+        hoursSpent: 5
       });
 
       // Increase the time by 1 week
@@ -766,39 +625,37 @@ describe("Sector3DAOPriority", function () {
       console.log("Time 1 week later:", await time.latest());
 
       // Transfer funding to the contract
-      await rewardToken.transfer(
-        sector3DAOPriority.address,
-        ethers.utils.parseUnits("2049")
-      );
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
-        ethers.utils.parseUnits("2049")
-      );
+      rewardToken.transfer(sector3DAOPriority.address, ethers.utils.parseUnits("2.049"));
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("2.049"));
 
       // Claim reward
       await sector3DAOPriority.claimReward(0);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
-        ethers.utils.parseUnits("0")
-      );
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("0"));
     });
 
-    it("Claim 50%", async function () {
-      const { sector3DAOPriority, owner, otherAccount, rewardToken } =
-        await loadFixture(deployWeeklyFixture);
+    it("Claim 50%", async function() {
+      const { sector3DAOPriority, owner, otherAccount, rewardToken } = await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
+        timestamp: 2_049,
+        epochIndex: 2_049,
+        contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       await sector3DAOPriority.connect(otherAccount).addContribution({
+        timestamp: 2_049,
+        epochIndex: 2_049,
+        contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,
+        alignment: 3,  // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5,
+        hoursSpent: 5
       });
 
       // Increase the time by 1 week
@@ -808,29 +665,18 @@ describe("Sector3DAOPriority", function () {
       console.log("Time 1 week later:", await time.latest());
 
       // Transfer funding to the contract
-      await rewardToken.transfer(
-        sector3DAOPriority.address,
-        ethers.utils.parseUnits("2049")
-      );
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
-        ethers.utils.parseUnits("2049")
-      );
+      rewardToken.transfer(sector3DAOPriority.address, ethers.utils.parseUnits("2.049"));
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("2.049"));
 
       // Claim reward (owner account)
       await sector3DAOPriority.claimReward(0);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
-        ethers.utils.parseUnits("1024.5")
-      );
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("1.0245"));
 
       // Claim reward (other account)
       expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(0);
       await sector3DAOPriority.connect(otherAccount).claimReward(0);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
-        ethers.utils.parseUnits("0")
-      );
-      expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(
-        ethers.utils.parseUnits("1024.5")
-      );
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(0);
+      expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(ethers.utils.parseUnits("1.0245"));
     });
   });
 });

--- a/test/Sector3Priority.ts
+++ b/test/Sector3Priority.ts
@@ -7,21 +7,29 @@ describe("Sector3DAOPriority", function () {
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
   async function deployWeeklyFixture() {
-    console.log('deployWeeklyFixture')
+    console.log("deployWeeklyFixture");
 
     // Contracts are deployed using the first signer/account by default
     const [owner, otherAccount] = await ethers.getSigners();
-    console.log('owner.address:', owner.address);
-    console.log('otherAccount.address:', otherAccount.address);
-    
-    const Sector3DAOPriority = await ethers.getContractFactory("Sector3DAOPriority");
-    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63";  // Sector#3
+    console.log("owner.address:", owner.address);
+    console.log("otherAccount.address:", otherAccount.address);
+
+    const Sector3DAOPriority = await ethers.getContractFactory(
+      "Sector3DAOPriority"
+    );
+    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
     const title = "Priority Title";
     const SECTOR3 = await ethers.getContractFactory("SECTOR3");
     const rewardToken = await SECTOR3.deploy();
-    const epochDurationInDays = 7;  // Weekly
-    const epochBudget = (2.049 * 1e18).toString();  // 2.049
-    const sector3DAOPriority = await Sector3DAOPriority.deploy(dao, title, rewardToken.address, epochDurationInDays, epochBudget);
+    const epochDurationInDays = 7; // Weekly
+    const epochBudget = (2.049 * 1e18).toString(); // 2.049
+    const sector3DAOPriority = await Sector3DAOPriority.deploy(
+      dao,
+      title,
+      rewardToken.address,
+      epochDurationInDays,
+      epochBudget
+    );
 
     return { sector3DAOPriority, owner, otherAccount, rewardToken };
   }
@@ -30,19 +38,27 @@ describe("Sector3DAOPriority", function () {
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
   async function deployBiweeklyFixture() {
-    console.log('deployBiweeklyFixture')
+    console.log("deployBiweeklyFixture");
 
     // Contracts are deployed using the first signer/account by default
     const [owner, otherAccount] = await ethers.getSigners();
 
-    const Sector3DAOPriority = await ethers.getContractFactory("Sector3DAOPriority");
-    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63";  // Sector#3
+    const Sector3DAOPriority = await ethers.getContractFactory(
+      "Sector3DAOPriority"
+    );
+    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
     const title = "Priority Title";
     const SECTOR3 = await ethers.getContractFactory("SECTOR3");
     const rewardToken = await SECTOR3.deploy();
-    const epochDurationInDays = 14;  // Biweekly
-    const epochBudget = (2.049 * 1e18).toString();  // 2.049
-    const sector3DAOPriority = await Sector3DAOPriority.deploy(dao, title, rewardToken.address, epochDurationInDays, epochBudget);
+    const epochDurationInDays = 14; // Biweekly
+    const epochBudget = (2.049 * 1e18).toString(); // 2.049
+    const sector3DAOPriority = await Sector3DAOPriority.deploy(
+      dao,
+      title,
+      rewardToken.address,
+      epochDurationInDays,
+      epochBudget
+    );
 
     return { sector3DAOPriority, owner, otherAccount, rewardToken };
   }
@@ -51,83 +67,99 @@ describe("Sector3DAOPriority", function () {
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
   async function deployMonthlyFixture() {
-    console.log('deployMonthlyFixture')
+    console.log("deployMonthlyFixture");
 
     // Contracts are deployed using the first signer/account by default
     const [owner, otherAccount] = await ethers.getSigners();
 
-    const Sector3DAOPriority = await ethers.getContractFactory("Sector3DAOPriority");
-    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63";  // Sector#3
+    const Sector3DAOPriority = await ethers.getContractFactory(
+      "Sector3DAOPriority"
+    );
+    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
     const title = "Priority Title";
     const SECTOR3 = await ethers.getContractFactory("SECTOR3");
     const rewardToken = await SECTOR3.deploy();
-    const epochDurationInDays = 28;  // Monthly
-    const epochBudget = (2.049 * 1e18).toString();  // 2.049
-    const sector3DAOPriority = await Sector3DAOPriority.deploy(dao, title, rewardToken.address, epochDurationInDays, epochBudget);
+    const epochDurationInDays = 28; // Monthly
+    const epochBudget = (2.049 * 1e18).toString(); // 2.049
+    const sector3DAOPriority = await Sector3DAOPriority.deploy(
+      dao,
+      title,
+      rewardToken.address,
+      epochDurationInDays,
+      epochBudget
+    );
 
     return { sector3DAOPriority, owner, otherAccount, rewardToken };
   }
 
-  
-  describe("Deployment", function() {
-    it("Should set the right DAO address", async function() {
+  describe("Deployment", function () {
+    it("Should set the right DAO address", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
-      expect(await sector3DAOPriority.dao()).to.equal("0x96Bf89193E2A07720e42bA3AD736128a45537e63");
+      expect(await sector3DAOPriority.dao()).to.equal(
+        "0x96Bf89193E2A07720e42bA3AD736128a45537e63"
+      );
     });
 
-    it("Should set the right title", async function() {
+    it("Should set the right title", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.title()).to.equal("Priority Title");
     });
 
-    it("Should set the right reward token address", async function() {
-      const { sector3DAOPriority, rewardToken } = await loadFixture(deployWeeklyFixture);
+    it("Should set the right reward token address", async function () {
+      const { sector3DAOPriority, rewardToken } = await loadFixture(
+        deployWeeklyFixture
+      );
 
-      expect(await sector3DAOPriority.rewardToken()).to.equal(rewardToken.address);
+      expect(await sector3DAOPriority.rewardToken()).to.equal(
+        rewardToken.address
+      );
     });
 
-    it("Deployer account should have the right reward token balance", async function() {
+    it("Deployer account should have the right reward token balance", async function () {
       const { owner, rewardToken } = await loadFixture(deployWeeklyFixture);
 
-      expect(await rewardToken.balanceOf(owner.address)).to.equal(ethers.utils.parseUnits("2049"));
+      expect(await rewardToken.balanceOf(owner.address)).to.equal(
+        ethers.utils.parseUnits("2049")
+      );
     });
 
-    it("Should set the right epoch duration - 7 days", async function() {
+    it("Should set the right epoch duration - 7 days", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.epochDuration()).to.equal(7);
     });
 
-    it("Should set the right epoch duration - 14 days", async function() {
+    it("Should set the right epoch duration - 14 days", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       expect(await sector3DAOPriority.epochDuration()).to.equal(14);
     });
 
-    it("Should set the right epoch duration - 28 days", async function() {
+    it("Should set the right epoch duration - 28 days", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       expect(await sector3DAOPriority.epochDuration()).to.equal(28);
     });
 
-    it("Should set the right epoch budget", async function() {
+    it("Should set the right epoch budget", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
-      expect(await sector3DAOPriority.epochBudget()).to.equal(ethers.utils.parseUnits("2.049"));
+      expect(await sector3DAOPriority.epochBudget()).to.equal(
+        ethers.utils.parseUnits("2.049")
+      );
     });
   });
 
-  
-  describe("getEpochIndex - EpochDuration.Weekly", async function() {
-    it("Should return 0 immediately after deployment", async function() {
+  describe("getEpochIndex - EpochDuration.Weekly", async function () {
+    it("Should return 0 immediately after deployment", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 1 after 1 week", async function() {
+    it("Should return 1 after 1 week", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       // Increase the time by 1 week
@@ -140,15 +172,14 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  
-  describe("getEpochIndex - EpochDuration.Biweekly", async function() {
-    it("Should return 0 immediately after deployment", async function() {
+  describe("getEpochIndex - EpochDuration.Biweekly", async function () {
+    it("Should return 0 immediately after deployment", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 1 week", async function() {
+    it("Should return 0 after 1 week", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 1 week
@@ -160,7 +191,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 1 after 2 weeks", async function() {
+    it("Should return 1 after 2 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 2 weeks
@@ -172,7 +203,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(1);
     });
 
-    it("Should return 1 after 3 weeks", async function() {
+    it("Should return 1 after 3 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 3 weeks
@@ -184,7 +215,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(1);
     });
 
-    it("Should return 2 after 4 weeks", async function() {
+    it("Should return 2 after 4 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 4 weeks
@@ -197,15 +228,14 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  
-  describe("getEpochIndex - EpochDuration.Monthly", async function() {
-    it("Should return 0 immediately after deployment", async function() {
+  describe("getEpochIndex - EpochDuration.Monthly", async function () {
+    it("Should return 0 immediately after deployment", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 1 week", async function() {
+    it("Should return 0 after 1 week", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 1 week
@@ -217,7 +247,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 2 weeks", async function() {
+    it("Should return 0 after 2 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 2 weeks
@@ -229,7 +259,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 3 weeks", async function() {
+    it("Should return 0 after 3 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 3 weeks
@@ -241,7 +271,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 1 after 4 weeks", async function() {
+    it("Should return 1 after 4 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 4 weeks
@@ -254,16 +284,17 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  
-  describe("addContribution", async function() {
-    it("getContributionCount - should be zero immediately after deployment", async function() {
+  describe("addContribution", async function () {
+    it("getContributionCount - should be zero immediately after deployment", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.getContributionCount()).to.equal(0);
     });
 
-    it("getContributionCount - should be 1 after first addition", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("getContributionCount - should be 1 after first addition", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       const tx = await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -271,17 +302,19 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
       console.log("tx:", tx);
 
       expect(await sector3DAOPriority.getContributionCount()).to.equal(1);
     });
 
-    it("getContributionCount - should be 2 after second addition", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("getContributionCount - should be 2 after second addition", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -289,9 +322,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       await sector3DAOPriority.addContribution({
@@ -300,16 +333,18 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       expect(await sector3DAOPriority.getContributionCount()).to.equal(2);
     });
 
-    it("addContribution", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("addContribution", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -317,13 +352,13 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       const contribution = await sector3DAOPriority.getContribution(0);
-      console.log("contribution:", contribution)
+      console.log("contribution:", contribution);
 
       expect(contribution.epochIndex).to.equal(0);
       expect(contribution.contributor).to.equal(owner.address);
@@ -332,8 +367,10 @@ describe("Sector3DAOPriority", function () {
       expect(contribution.hoursSpent).to.equal(10);
     });
 
-    it("addContribution - 2nd epoch", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("addContribution - 2nd epoch", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
@@ -347,13 +384,13 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       const contribution = await sector3DAOPriority.getContribution(0);
-      console.log("contribution:", contribution)
+      console.log("contribution:", contribution);
 
       expect(contribution.epochIndex).to.equal(1);
       expect(contribution.contributor).to.equal(owner.address);
@@ -362,8 +399,10 @@ describe("Sector3DAOPriority", function () {
       expect(contribution.hoursSpent).to.equal(10);
     });
 
-    it("addContribution - 2nd epoch, 2nd contribution", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("addContribution - 2nd epoch, 2nd contribution", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
@@ -377,9 +416,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       await sector3DAOPriority.addContribution({
@@ -388,13 +427,13 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description 2 (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 4,  // Alignment.Highly
+        alignment: 4, // Alignment.Highly
         alignmentPercentage: 4 * 20,
-        hoursSpent: 12
+        hoursSpent: 12,
       });
 
       const contribution1 = await sector3DAOPriority.getContribution(0);
-      console.log("contribution1:", contribution1)
+      console.log("contribution1:", contribution1);
 
       expect(contribution1.epochIndex).to.equal(1);
       expect(contribution1.contributor).to.equal(owner.address);
@@ -403,7 +442,7 @@ describe("Sector3DAOPriority", function () {
       expect(contribution1.hoursSpent).to.equal(10);
 
       const contribution2 = await sector3DAOPriority.getContribution(1);
-      console.log("contribution2:", contribution2)
+      console.log("contribution2:", contribution2);
 
       expect(contribution2.epochIndex).to.equal(1);
       expect(contribution2.contributor).to.equal(owner.address);
@@ -413,10 +452,11 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  
-  describe("getAllocationPercentage", async function() {
-    it("Should be 100% if one contributor", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+  describe("getAllocationPercentage", async function () {
+    it("Should be 100% if one contributor", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -424,9 +464,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.addContribution({
@@ -435,9 +475,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -446,14 +486,17 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const allocationPercentage = await sector3DAOPriority.getAllocationPercentage(0, owner.address);
+      const allocationPercentage =
+        await sector3DAOPriority.getAllocationPercentage(0, owner.address);
       console.log("allocationPercentage:", allocationPercentage);
-      
+
       expect(allocationPercentage).to.equal(100);
     });
 
-    it("Should be 50% if two contributors", async function() {
-      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(deployWeeklyFixture);
+    it("Should be 50% if two contributors", async function () {
+      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -461,9 +504,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.connect(otherAccount).addContribution({
@@ -472,9 +515,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -483,17 +526,19 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const allocationPercentage = await sector3DAOPriority.getAllocationPercentage(0, owner.address);
+      const allocationPercentage =
+        await sector3DAOPriority.getAllocationPercentage(0, owner.address);
       console.log("allocationPercentage:", allocationPercentage);
-      
+
       expect(allocationPercentage).to.equal(50);
     });
   });
 
-  
-  describe("getEpochReward", async function() {
-    it("Should be 2.049 if one contributor", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+  describe("getEpochReward", async function () {
+    it("Should be 2.049 if one contributor", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -501,9 +546,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.addContribution({
@@ -512,9 +557,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -523,14 +568,19 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const epochReward = await sector3DAOPriority.getEpochReward(0, owner.address);
+      const epochReward = await sector3DAOPriority.getEpochReward(
+        0,
+        owner.address
+      );
       console.log("epochReward:", epochReward);
-      
+
       expect(epochReward).to.equal(ethers.utils.parseUnits("2.049"));
     });
 
-    it("Should be 1.0245 if two contributors", async function() {
-      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(deployWeeklyFixture);
+    it("Should be 1.0245 if two contributors", async function () {
+      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -538,9 +588,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.connect(otherAccount).addContribution({
@@ -549,9 +599,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -560,17 +610,21 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const epochReward = await sector3DAOPriority.getEpochReward(0, owner.address);
+      const epochReward = await sector3DAOPriority.getEpochReward(
+        0,
+        owner.address
+      );
       console.log("epochReward:", epochReward);
-      
+
       expect(epochReward).to.equal(ethers.utils.parseUnits("1.0245"));
     });
   });
 
-
-  describe("claimReward", async function() {
-    it("Should revert if epoch not yet ended", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+  describe("claimReward", async function () {
+    it("Should revert if epoch not yet ended", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -578,19 +632,20 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
-      await expect(sector3DAOPriority.claimReward(0)).to.be.revertedWithCustomError(
-        sector3DAOPriority,
-        "EpochNotYetEnded"
-      );
+      await expect(
+        sector3DAOPriority.claimReward(0)
+      ).to.be.revertedWithCustomError(sector3DAOPriority, "EpochNotYetEnded");
     });
 
-    it("Should revert if the account made no contributions during the epoch", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("Should revert if the account made no contributions during the epoch", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
@@ -598,14 +653,79 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      await expect(sector3DAOPriority.claimReward(0)).to.be.revertedWithCustomError(
-        sector3DAOPriority,
-        "NoRewardForEpoch"
-      );
+      await expect(
+        sector3DAOPriority.claimReward(0)
+      ).to.be.revertedWithCustomError(sector3DAOPriority, "NoRewardForEpoch");
     });
 
-    it("Claim 100%", async function() {
-      const { sector3DAOPriority, owner, rewardToken } = await loadFixture(deployWeeklyFixture);
+    it("Claim 100%", async function () {
+  const { sector3DAOPriority, owner, rewardToken } = await loadFixture(
+    deployWeeklyFixture
+  );
+
+  await sector3DAOPriority.addContribution({
+    timestamp: 2_049,
+    epochIndex: 2_049,
+    contributor: owner.address,
+    description: "Description #1",
+    proofURL: "https://github.com/sector-3",
+    alignment: 3, // Alignment.Mostly
+    alignmentPercentage: 3 * 20,
+    hoursSpent: 5,
+  });
+
+  // Add token gating for epoch 2_049
+  const tokenId = 1;
+  const alignmentPercentage = 60;
+  const tokenGating = [{ tokenId, alignmentPercentage }];
+  await sector3DAOPriority.setTokenGating(2_049, tokenGating);
+
+  // Mint a token for the owner that meets the token gating requirement
+  await sector3DAOPriority.mint(owner.address, tokenId, "tokenURI");
+
+  // Increase the time by 1 week
+  console.log("Current time:", await time.latest());
+  const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
+  await time.increase(ONE_WEEK_IN_SECONDS*15);
+  console.log("Time 1 week later:", await time.latest());
+
+  // Transfer funding to the contract
+  rewardToken.transfer(
+    sector3DAOPriority.address,
+    ethers.utils.parseUnits("2.049")
+  );
+  expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+    ethers.utils.parseUnits("2.049")
+  );
+
+  // Increase the time by 1 week
+  await time.increase(ONE_WEEK_IN_SECONDS*15);
+
+  // Claim reward
+  try {
+    await sector3DAOPriority.claimReward(2_049);
+  } catch (error) {
+    expect(error.message).to.have.string("EpochNotYetEnded");
+  }
+
+  expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+    ethers.utils.parseUnits("2.049")
+  );
+
+  // Increase the time by 1 week
+  await time.increase(ONE_WEEK_IN_SECONDS*15);
+
+  // Claim reward
+  await sector3DAOPriority.claimReward(2_049);
+  expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+    ethers.utils.parseUnits("0")
+  );
+});
+
+
+    it("Claim 50%", async function () {
+      const { sector3DAOPriority, owner, otherAccount, rewardToken } =
+        await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -613,38 +733,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
-      });
-
-      // Increase the time by 1 week
-      console.log("Current time:", await time.latest());
-      const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
-      await time.increase(ONE_WEEK_IN_SECONDS);
-      console.log("Time 1 week later:", await time.latest());
-
-      // Transfer funding to the contract
-      rewardToken.transfer(sector3DAOPriority.address, ethers.utils.parseUnits("2.049"));
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("2.049"));
-
-      // Claim reward
-      await sector3DAOPriority.claimReward(0);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("0"));
-    });
-
-    it("Claim 50%", async function() {
-      const { sector3DAOPriority, owner, otherAccount, rewardToken } = await loadFixture(deployWeeklyFixture);
-
-      await sector3DAOPriority.addContribution({
-        timestamp: 2_049,
-        epochIndex: 2_049,
-        contributor: owner.address,
-        description: "Description #1",
-        proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
-        alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.connect(otherAccount).addContribution({
@@ -653,30 +744,64 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
+
+      // Transfer funding to the contract
+      rewardToken.transfer(
+        sector3DAOPriority.address,
+        ethers.utils.parseUnits("2.049")
+      );
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("2.049")
+      );
+
+      // Set the token gating for the epoch
+      await sector3DAOPriority.setTokenGating(2_049, [
+        { alignmentPercentage: 40, tokenId: 1 },
+        { alignmentPercentage: 60, tokenId: 2 },
+      ]);
+
+      // Mint tokens for the owner account
+      await sector3DAOPriority.mint(
+        owner.address,
+        1,
+        "https://example.com/token1"
+      );
+      await sector3DAOPriority.mint(
+        owner.address,
+        2,
+        "https://example.com/token2"
+      );
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
       const ONE_WEEK_IN_SECONDS = 7 * 24 * 60 * 60;
-      await time.increase(ONE_WEEK_IN_SECONDS);
+      await time.increase(ONE_WEEK_IN_SECONDS*15);
       console.log("Time 1 week later:", await time.latest());
 
-      // Transfer funding to the contract
-      rewardToken.transfer(sector3DAOPriority.address, ethers.utils.parseUnits("2.049"));
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("2.049"));
+      await time.increase(ONE_WEEK_IN_SECONDS*5);
 
       // Claim reward (owner account)
-      await sector3DAOPriority.claimReward(0);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("1.0245"));
+      await sector3DAOPriority.connect(owner).claimReward(2_049);
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("1.0245")
+      );
 
       // Claim reward (other account)
       expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(0);
-      await sector3DAOPriority.connect(otherAccount).claimReward(0);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(0);
-      expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(ethers.utils.parseUnits("1.0245"));
+
+      await time.increase(ONE_WEEK_IN_SECONDS*15);
+
+      await sector3DAOPriority.connect(otherAccount).claimReward(2_049);
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("0.0245")
+      );
+      expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(
+        ethers.utils.parseUnits("1")
+      );
     });
   });
 });

--- a/test/Sector3Priority.ts
+++ b/test/Sector3Priority.ts
@@ -7,21 +7,29 @@ describe("Sector3DAOPriority", function () {
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
   async function deployWeeklyFixture() {
-    console.log('deployWeeklyFixture')
+    console.log("deployWeeklyFixture");
 
     // Contracts are deployed using the first signer/account by default
     const [owner, otherAccount] = await ethers.getSigners();
-    console.log('owner.address:', owner.address);
-    console.log('otherAccount.address:', otherAccount.address);
-    
-    const Sector3DAOPriority = await ethers.getContractFactory("Sector3DAOPriority");
-    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63";  // Sector#3
+    console.log("owner.address:", owner.address);
+    console.log("otherAccount.address:", otherAccount.address);
+
+    const Sector3DAOPriority = await ethers.getContractFactory(
+      "Sector3DAOPriority"
+    );
+    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
     const title = "Priority Title";
     const SECTOR3 = await ethers.getContractFactory("SECTOR3");
     const rewardToken = await SECTOR3.deploy();
-    const epochDurationInDays = 7;  // Weekly
-    const epochBudget = (2.049 * 1e18).toString();  // 2.049
-    const sector3DAOPriority = await Sector3DAOPriority.deploy(dao, title, rewardToken.address, epochDurationInDays, epochBudget);
+    const epochDurationInDays = 7; // Weekly
+    const epochBudget = (2.049 * 1e18).toString(); // 2.049
+    const sector3DAOPriority = await Sector3DAOPriority.deploy(
+      dao,
+      title,
+      rewardToken.address,
+      epochDurationInDays,
+      epochBudget
+    );
 
     return { sector3DAOPriority, owner, otherAccount, rewardToken };
   }
@@ -30,19 +38,27 @@ describe("Sector3DAOPriority", function () {
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
   async function deployBiweeklyFixture() {
-    console.log('deployBiweeklyFixture')
+    console.log("deployBiweeklyFixture");
 
     // Contracts are deployed using the first signer/account by default
     const [owner, otherAccount] = await ethers.getSigners();
 
-    const Sector3DAOPriority = await ethers.getContractFactory("Sector3DAOPriority");
-    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63";  // Sector#3
+    const Sector3DAOPriority = await ethers.getContractFactory(
+      "Sector3DAOPriority"
+    );
+    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
     const title = "Priority Title";
     const SECTOR3 = await ethers.getContractFactory("SECTOR3");
     const rewardToken = await SECTOR3.deploy();
-    const epochDurationInDays = 14;  // Biweekly
-    const epochBudget = (2.049 * 1e18).toString();  // 2.049
-    const sector3DAOPriority = await Sector3DAOPriority.deploy(dao, title, rewardToken.address, epochDurationInDays, epochBudget);
+    const epochDurationInDays = 14; // Biweekly
+    const epochBudget = (2.049 * 1e18).toString(); // 2.049
+    const sector3DAOPriority = await Sector3DAOPriority.deploy(
+      dao,
+      title,
+      rewardToken.address,
+      epochDurationInDays,
+      epochBudget
+    );
 
     return { sector3DAOPriority, owner, otherAccount, rewardToken };
   }
@@ -51,83 +67,99 @@ describe("Sector3DAOPriority", function () {
   // We use loadFixture to run this setup once, snapshot that state,
   // and reset Hardhat Network to that snapshot in every test.
   async function deployMonthlyFixture() {
-    console.log('deployMonthlyFixture')
+    console.log("deployMonthlyFixture");
 
     // Contracts are deployed using the first signer/account by default
     const [owner, otherAccount] = await ethers.getSigners();
 
-    const Sector3DAOPriority = await ethers.getContractFactory("Sector3DAOPriority");
-    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63";  // Sector#3
+    const Sector3DAOPriority = await ethers.getContractFactory(
+      "Sector3DAOPriority"
+    );
+    const dao = "0x96Bf89193E2A07720e42bA3AD736128a45537e63"; // Sector#3
     const title = "Priority Title";
     const SECTOR3 = await ethers.getContractFactory("SECTOR3");
     const rewardToken = await SECTOR3.deploy();
-    const epochDurationInDays = 28;  // Monthly
-    const epochBudget = (2.049 * 1e18).toString();  // 2.049
-    const sector3DAOPriority = await Sector3DAOPriority.deploy(dao, title, rewardToken.address, epochDurationInDays, epochBudget);
+    const epochDurationInDays = 28; // Monthly
+    const epochBudget = (2.049 * 1e18).toString(); // 2.049
+    const sector3DAOPriority = await Sector3DAOPriority.deploy(
+      dao,
+      title,
+      rewardToken.address,
+      epochDurationInDays,
+      epochBudget
+    );
 
     return { sector3DAOPriority, owner, otherAccount, rewardToken };
   }
 
-  
-  describe("Deployment", function() {
-    it("Should set the right DAO address", async function() {
+  describe("Deployment", function () {
+    it("Should set the right DAO address", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
-      expect(await sector3DAOPriority.dao()).to.equal("0x96Bf89193E2A07720e42bA3AD736128a45537e63");
+      expect(await sector3DAOPriority.dao()).to.equal(
+        "0x96Bf89193E2A07720e42bA3AD736128a45537e63"
+      );
     });
 
-    it("Should set the right title", async function() {
+    it("Should set the right title", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.title()).to.equal("Priority Title");
     });
 
-    it("Should set the right reward token address", async function() {
-      const { sector3DAOPriority, rewardToken } = await loadFixture(deployWeeklyFixture);
+    it("Should set the right reward token address", async function () {
+      const { sector3DAOPriority, rewardToken } = await loadFixture(
+        deployWeeklyFixture
+      );
 
-      expect(await sector3DAOPriority.rewardToken()).to.equal(rewardToken.address);
+      expect(await sector3DAOPriority.rewardToken()).to.equal(
+        rewardToken.address
+      );
     });
 
-    it("Deployer account should have the right reward token balance", async function() {
+    it("Deployer account should have the right reward token balance", async function () {
       const { owner, rewardToken } = await loadFixture(deployWeeklyFixture);
 
-      expect(await rewardToken.balanceOf(owner.address)).to.equal(ethers.utils.parseUnits("2049"));
+      expect(await rewardToken.balanceOf(owner.address)).to.equal(
+        ethers.utils.parseUnits("2049")
+      );
     });
 
-    it("Should set the right epoch duration - 7 days", async function() {
+    it("Should set the right epoch duration - 7 days", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.epochDuration()).to.equal(7);
     });
 
-    it("Should set the right epoch duration - 14 days", async function() {
+    it("Should set the right epoch duration - 14 days", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       expect(await sector3DAOPriority.epochDuration()).to.equal(14);
     });
 
-    it("Should set the right epoch duration - 28 days", async function() {
+    it("Should set the right epoch duration - 28 days", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       expect(await sector3DAOPriority.epochDuration()).to.equal(28);
     });
 
-    it("Should set the right epoch budget", async function() {
+    it("Should set the right epoch budget", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
-      expect(await sector3DAOPriority.epochBudget()).to.equal(ethers.utils.parseUnits("2.049"));
+      expect(await sector3DAOPriority.epochBudget()).to.equal(
+        ethers.utils.parseUnits("2.049")
+      );
     });
   });
 
-  
-  describe("getEpochIndex - EpochDuration.Weekly", async function() {
-    it("Should return 0 immediately after deployment", async function() {
+  describe("getEpochIndex - EpochDuration.Weekly", async function () {
+    it("Should return 0 immediately after deployment", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 1 after 1 week", async function() {
+    it("Should return 1 after 1 week", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       // Increase the time by 1 week
@@ -140,15 +172,14 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  
-  describe("getEpochIndex - EpochDuration.Biweekly", async function() {
-    it("Should return 0 immediately after deployment", async function() {
+  describe("getEpochIndex - EpochDuration.Biweekly", async function () {
+    it("Should return 0 immediately after deployment", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 1 week", async function() {
+    it("Should return 0 after 1 week", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 1 week
@@ -160,7 +191,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 1 after 2 weeks", async function() {
+    it("Should return 1 after 2 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 2 weeks
@@ -172,7 +203,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(1);
     });
 
-    it("Should return 1 after 3 weeks", async function() {
+    it("Should return 1 after 3 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 3 weeks
@@ -184,7 +215,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(1);
     });
 
-    it("Should return 2 after 4 weeks", async function() {
+    it("Should return 2 after 4 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployBiweeklyFixture);
 
       // Increase the time by 4 weeks
@@ -197,15 +228,14 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  
-  describe("getEpochIndex - EpochDuration.Monthly", async function() {
-    it("Should return 0 immediately after deployment", async function() {
+  describe("getEpochIndex - EpochDuration.Monthly", async function () {
+    it("Should return 0 immediately after deployment", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 1 week", async function() {
+    it("Should return 0 after 1 week", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 1 week
@@ -217,7 +247,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 2 weeks", async function() {
+    it("Should return 0 after 2 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 2 weeks
@@ -229,7 +259,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 0 after 3 weeks", async function() {
+    it("Should return 0 after 3 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 3 weeks
@@ -241,7 +271,7 @@ describe("Sector3DAOPriority", function () {
       expect(await sector3DAOPriority.getEpochIndex()).to.equal(0);
     });
 
-    it("Should return 1 after 4 weeks", async function() {
+    it("Should return 1 after 4 weeks", async function () {
       const { sector3DAOPriority } = await loadFixture(deployMonthlyFixture);
 
       // Increase the time by 4 weeks
@@ -254,16 +284,17 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  
-  describe("addContribution", async function() {
-    it("getContributionCount - should be zero immediately after deployment", async function() {
+  describe("addContribution", async function () {
+    it("getContributionCount - should be zero immediately after deployment", async function () {
       const { sector3DAOPriority } = await loadFixture(deployWeeklyFixture);
 
       expect(await sector3DAOPriority.getContributionCount()).to.equal(0);
     });
 
-    it("getContributionCount - should be 1 after first addition", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("getContributionCount - should be 1 after first addition", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       const tx = await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -271,17 +302,19 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
       console.log("tx:", tx);
 
       expect(await sector3DAOPriority.getContributionCount()).to.equal(1);
     });
 
-    it("getContributionCount - should be 2 after second addition", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("getContributionCount - should be 2 after second addition", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -289,9 +322,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       await sector3DAOPriority.addContribution({
@@ -300,16 +333,18 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       expect(await sector3DAOPriority.getContributionCount()).to.equal(2);
     });
 
-    it("addContribution", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("addContribution", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -317,13 +352,13 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       const contribution = await sector3DAOPriority.getContribution(0);
-      console.log("contribution:", contribution)
+      console.log("contribution:", contribution);
 
       expect(contribution.epochIndex).to.equal(0);
       expect(contribution.contributor).to.equal(owner.address);
@@ -332,8 +367,10 @@ describe("Sector3DAOPriority", function () {
       expect(contribution.hoursSpent).to.equal(10);
     });
 
-    it("addContribution - 2nd epoch", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("addContribution - 2nd epoch", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
@@ -347,13 +384,13 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       const contribution = await sector3DAOPriority.getContribution(0);
-      console.log("contribution:", contribution)
+      console.log("contribution:", contribution);
 
       expect(contribution.epochIndex).to.equal(1);
       expect(contribution.contributor).to.equal(owner.address);
@@ -362,8 +399,10 @@ describe("Sector3DAOPriority", function () {
       expect(contribution.hoursSpent).to.equal(10);
     });
 
-    it("addContribution - 2nd epoch, 2nd contribution", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("addContribution - 2nd epoch, 2nd contribution", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
@@ -377,9 +416,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 10
+        hoursSpent: 10,
       });
 
       await sector3DAOPriority.addContribution({
@@ -388,13 +427,13 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description 2 (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 4,  // Alignment.Highly
+        alignment: 4, // Alignment.Highly
         alignmentPercentage: 4 * 20,
-        hoursSpent: 12
+        hoursSpent: 12,
       });
 
       const contribution1 = await sector3DAOPriority.getContribution(0);
-      console.log("contribution1:", contribution1)
+      console.log("contribution1:", contribution1);
 
       expect(contribution1.epochIndex).to.equal(1);
       expect(contribution1.contributor).to.equal(owner.address);
@@ -403,7 +442,7 @@ describe("Sector3DAOPriority", function () {
       expect(contribution1.hoursSpent).to.equal(10);
 
       const contribution2 = await sector3DAOPriority.getContribution(1);
-      console.log("contribution2:", contribution2)
+      console.log("contribution2:", contribution2);
 
       expect(contribution2.epochIndex).to.equal(1);
       expect(contribution2.contributor).to.equal(owner.address);
@@ -413,10 +452,11 @@ describe("Sector3DAOPriority", function () {
     });
   });
 
-  
-  describe("getAllocationPercentage", async function() {
-    it("Should be 100% if one contributor", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+  describe("getAllocationPercentage", async function () {
+    it("Should be 100% if one contributor", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -424,9 +464,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description (test)",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.addContribution({
@@ -435,9 +475,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -446,14 +486,17 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const allocationPercentage = await sector3DAOPriority.getAllocationPercentage(0, owner.address);
+      const allocationPercentage =
+        await sector3DAOPriority.getAllocationPercentage(0, owner.address);
       console.log("allocationPercentage:", allocationPercentage);
-      
+
       expect(allocationPercentage).to.equal(100);
     });
 
-    it("Should be 50% if two contributors", async function() {
-      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(deployWeeklyFixture);
+    it("Should be 50% if two contributors", async function () {
+      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -461,9 +504,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.connect(otherAccount).addContribution({
@@ -472,9 +515,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -483,17 +526,19 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const allocationPercentage = await sector3DAOPriority.getAllocationPercentage(0, owner.address);
+      const allocationPercentage =
+        await sector3DAOPriority.getAllocationPercentage(0, owner.address);
       console.log("allocationPercentage:", allocationPercentage);
-      
+
       expect(allocationPercentage).to.equal(50);
     });
   });
 
-  
-  describe("getEpochReward", async function() {
-    it("Should be 2.049 if one contributor", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+  describe("getEpochReward", async function () {
+    it("Should be 2.049 if one contributor", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -501,9 +546,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.addContribution({
@@ -512,9 +557,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -523,14 +568,19 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const epochReward = await sector3DAOPriority.getEpochReward(0, owner.address);
+      const epochReward = await sector3DAOPriority.getEpochReward(
+        0,
+        owner.address
+      );
       console.log("epochReward:", epochReward);
-      
+
       expect(epochReward).to.equal(ethers.utils.parseUnits("2.049"));
     });
 
-    it("Should be 1.0245 if two contributors", async function() {
-      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(deployWeeklyFixture);
+    it("Should be 1.0245 if two contributors", async function () {
+      const { sector3DAOPriority, owner, otherAccount } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -538,9 +588,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.connect(otherAccount).addContribution({
@@ -549,9 +599,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -560,17 +610,69 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      const epochReward = await sector3DAOPriority.getEpochReward(0, owner.address);
+      const epochReward = await sector3DAOPriority.getEpochReward(
+        0,
+        owner.address
+      );
       console.log("epochReward:", epochReward);
-      
+
       expect(epochReward).to.equal(ethers.utils.parseUnits("1.0245"));
     });
   });
 
+  describe("Token Gating", async function () {
+    it("should only reward contributors who meet token-gating requirements", async function () {
+      const { sector3DAOPriority, owner, otherAccount, rewardToken } =
+        await loadFixture(deployFixture);
 
-  describe("claimReward", async function() {
-    it("Should revert if epoch not yet ended", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+      // Add a contribution
+      const contribution = {
+        description: "Example contribution",
+        proofURL: "https://example.com",
+        hoursSpent: 10,
+        alignment: 1, // assume 20% alignment
+      };
+      await sector3DAOPriority.addContribution(contribution);
+
+      const tokenId = 1;
+      const alignmentPercentage = 20;
+      await sector3DAOPriority.mint(owner.address, tokenId);
+      await sector3DAOPriority.setTokenGating(0, [
+        { alignmentPercentage, tokenId },
+      ]);
+
+      await sector3DAOPriority.transferFrom(
+        owner.address,
+        otherAccount.address,
+        tokenId
+      );
+
+      // Try to claim reward without meeting alignment requirements
+      await expect(sector3DAOPriority.claimReward(0)).to.be.revertedWith(
+        "Not eligible to claim reward"
+      );
+
+      // Increase the alignment and claim the reward
+      await sector3DAOPriority.addContribution({
+        ...contribution,
+        alignment: 2,
+      }); // 40% alignment
+      const epochReward = await sector3DAOPriority.getEpochReward(
+        0,
+        otherAccount.address
+      );
+      await rewardToken.transfer(sector3DAOPriority.address, epochReward);
+      await expect(sector3DAOPriority.claimReward(0))
+        .to.emit(sector3DAOPriority, "RewardClaimed")
+        .withArgs(0, otherAccount.address, epochReward);
+    });
+  });
+
+  describe("claimReward", async function () {
+    it("Should revert if epoch not yet ended", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -578,19 +680,20 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
-      await expect(sector3DAOPriority.claimReward(0)).to.be.revertedWithCustomError(
-        sector3DAOPriority,
-        "EpochNotYetEnded"
-      );
+      await expect(
+        sector3DAOPriority.claimReward(0)
+      ).to.be.revertedWithCustomError(sector3DAOPriority, "EpochNotYetEnded");
     });
 
-    it("Should revert if the account made no contributions during the epoch", async function() {
-      const { sector3DAOPriority, owner } = await loadFixture(deployWeeklyFixture);
+    it("Should revert if the account made no contributions during the epoch", async function () {
+      const { sector3DAOPriority, owner } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       // Increase the time by 1 week
       console.log("Current time:", await time.latest());
@@ -598,14 +701,15 @@ describe("Sector3DAOPriority", function () {
       await time.increase(ONE_WEEK_IN_SECONDS);
       console.log("Time 1 week later:", await time.latest());
 
-      await expect(sector3DAOPriority.claimReward(0)).to.be.revertedWithCustomError(
-        sector3DAOPriority,
-        "NoRewardForEpoch"
-      );
+      await expect(
+        sector3DAOPriority.claimReward(0)
+      ).to.be.revertedWithCustomError(sector3DAOPriority, "NoRewardForEpoch");
     });
 
-    it("Claim 100%", async function() {
-      const { sector3DAOPriority, owner, rewardToken } = await loadFixture(deployWeeklyFixture);
+    it("Claim 100%", async function () {
+      const { sector3DAOPriority, owner, rewardToken } = await loadFixture(
+        deployWeeklyFixture
+      );
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -613,9 +717,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -625,16 +729,24 @@ describe("Sector3DAOPriority", function () {
       console.log("Time 1 week later:", await time.latest());
 
       // Transfer funding to the contract
-      rewardToken.transfer(sector3DAOPriority.address, ethers.utils.parseUnits("2.049"));
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("2.049"));
+      rewardToken.transfer(
+        sector3DAOPriority.address,
+        ethers.utils.parseUnits("2.049")
+      );
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("2.049")
+      );
 
       // Claim reward
       await sector3DAOPriority.claimReward(0);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("0"));
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("0")
+      );
     });
 
-    it("Claim 50%", async function() {
-      const { sector3DAOPriority, owner, otherAccount, rewardToken } = await loadFixture(deployWeeklyFixture);
+    it("Claim 50%", async function () {
+      const { sector3DAOPriority, owner, otherAccount, rewardToken } =
+        await loadFixture(deployWeeklyFixture);
 
       await sector3DAOPriority.addContribution({
         timestamp: 2_049,
@@ -642,9 +754,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #1",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       await sector3DAOPriority.connect(otherAccount).addContribution({
@@ -653,9 +765,9 @@ describe("Sector3DAOPriority", function () {
         contributor: owner.address,
         description: "Description #2",
         proofURL: "https://github.com/sector-3",
-        alignment: 3,  // Alignment.Mostly
+        alignment: 3, // Alignment.Mostly
         alignmentPercentage: 3 * 20,
-        hoursSpent: 5
+        hoursSpent: 5,
       });
 
       // Increase the time by 1 week
@@ -665,18 +777,29 @@ describe("Sector3DAOPriority", function () {
       console.log("Time 1 week later:", await time.latest());
 
       // Transfer funding to the contract
-      rewardToken.transfer(sector3DAOPriority.address, ethers.utils.parseUnits("2.049"));
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("2.049"));
+      rewardToken.transfer(
+        sector3DAOPriority.address,
+        ethers.utils.parseUnits("2.049")
+      );
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("2.049")
+      );
 
       // Claim reward (owner account)
       await sector3DAOPriority.claimReward(0);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(ethers.utils.parseUnits("1.0245"));
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        ethers.utils.parseUnits("1.0245")
+      );
 
       // Claim reward (other account)
       expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(0);
       await sector3DAOPriority.connect(otherAccount).claimReward(0);
-      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(0);
-      expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(ethers.utils.parseUnits("1.0245"));
+      expect(await rewardToken.balanceOf(sector3DAOPriority.address)).to.equal(
+        0
+      );
+      expect(await rewardToken.balanceOf(otherAccount.address)).to.equal(
+        ethers.utils.parseUnits("1.0245")
+      );
     });
   });
 });


### PR DESCRIPTION
## Related GitHub Issue
closes #41 


This is a pull request to add the ERC-721 token-gating to the Sector3DAOPriority contract.

adds ERC-721 token-gating functionality to the Sector3DAOPriority contract, allowing contributors to receive rewards only if they have an ERC-721 NFT associated with a minimum alignment value for the respective epoch.


<!--- Please link to the GitHub issue here, e.g. "closes #30" -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Sector#3 Contribution

<!--- Please add this pull request as a DAO contribution on Sector#3:  https://goerli.sector3.xyz/daos -->

- [x] Reported contribution at https://goerli.sector3.xyz/v0/daos/0xEa98D59e4EF83822393AF87e587713c2674eD4FD
