### PR TITLE
Refactor Sector3Governor.sol

### DIFF
--- a/contracts/governance/Sector3Governor.sol
+++ b/contracts/governance/Sector3Governor.sol
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import "@openzeppelin/contracts/governance/Governor.sol";
-import "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
-import "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
 import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorSettings.sol";
 
-contract Sector3Governor is Governor, GovernorSettings, GovernorCountingSimple, GovernorVotes, GovernorVotesQuorumFraction {
+contract Sector3Governor is GovernorVotes, GovernorVotesQuorumFraction, GovernorCountingSimple {
     constructor(IVotes _token)
         Governor("Sector#3 Governor")
-        GovernorSettings(1 /* 1 block */, 50400 /* ~1 week */, 2049e14 /* 0.2049 */)
+        GovernorSettings(1 /* 1 block */, 50400 /* ~1 week */, 2049e15 /* 2.049 */)
         GovernorVotes(_token)
         GovernorVotesQuorumFraction(1)
     {}


### PR DESCRIPTION
The Sector3Governor contract now directly inherits from GovernorVotes, GovernorVotesQuorumFraction, and GovernorCountingSimple. Removed the separate inheritance of Governor and GovernorSettings from Sector3Governor, as GovernorVotes already inherits from these contracts.

ref: https://github.com/sector-3/protocol/pull/70#pullrequestreview-1349484298

## Related GitHub Issue

<!--- Please link to the GitHub issue here, e.g. "closes #30" -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Sector#3 Contribution

<!--- Please add this pull request as a DAO contribution on Sector#3:  https://sector3.xyz -->

- [ ] Reported contribution at https://sector3.xyz/v1/daos/0x62Da9C79137dC9A8a6AdB1381476a1874CeCa9EE
